### PR TITLE
[fix] hint labels HTML

### DIFF
--- a/sources/hint.js
+++ b/sources/hint.js
@@ -61,8 +61,8 @@ webix.protoUI({
 	_drawHint() {
 		let settings = this.config;
 		this.$view.innerHTML += `<div class="webix_hint">
-			<span class='webix_hint_title'>${this._step.title?this._step.title:""}</span>
-			<p class="webix_hint_label">${this._step.text}</p>
+			<div class='webix_hint_title'>${this._step.title?this._step.title:""}</div>
+			<div class="webix_hint_label">${this._step.text}</div>
 			<div class="webix_hint_progress">
 				${this._i+1}/${this.config.steps.length}
 			</div>

--- a/sources/hint.less
+++ b/sources/hint.less
@@ -69,7 +69,6 @@
 		font-weight: 500;
 		line-height: 1;
 		margin-bottom: 15px;
-		display: block;
 	}
 }
 


### PR DESCRIPTION
p tag cannot include block elements: if they are, markup is parsed incorrectly

https://snippet.webix.com/4r0ar17m
